### PR TITLE
Fix namespace of invoked clobber task

### DIFF
--- a/lib/tasks/webpacker_lite/clobber.rake
+++ b/lib/tasks/webpacker_lite/clobber.rake
@@ -12,6 +12,6 @@ end
 # Run clobber if the assets:clobber is run
 if Rake::Task.task_defined?("assets:clobber")
   Rake::Task["assets:clobber"].enhance do
-    Rake::Task["webpacker:clobber"].invoke
+    Rake::Task["webpacker_lite:clobber"].invoke
   end
 end


### PR DESCRIPTION
Hey, when using webpacker_lite in my rails project I recognized `rake assets:clobber` failed bacause of a wrong namespace in the clobber task of webpacker_lite.
I made a small fix which worked for me locally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/webpacker_lite/11)
<!-- Reviewable:end -->
