### PR TITLE
Add helper pack_path to avoid calling asset_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Contributors: please follow the recommendations outlined at [keepachangelog.com]
 
 ## [Unreleased]
 *Please add entries here for your pull requests.*
+## [2.1.0] - 2017-07-18
+### Added
+* Expose helper pack_path for server rendering so asset_path is not called, so that a CDN is never used for server rendering in React on Rails. [#23](https://github.com/shakacode/webpacker_lite/pull/23) by [justin808](https://github.com/justin808).
+
 ## [2.0.4] - 2017-05-29
 ### Fixed
 * Code handles case of missing file and mtime. [#15](https://github.com/shakacode/webpacker_lite/pull/15) by [justin808](https://github.com/justin808).

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ for an asset used in your pack code you can reference them like this in your vie
 <% # real file path "public/webpack/calendar.png" /> %>
 ```
 
+The `pack_path` is the same as the `asset_pack_path` except that the Rails `asset_path` is not called on the file name. This is used by server rendering, as the `asset_path` is designed for browsers to access assets.
+
 ## Webpack Helper
 You may use the [React on Rails NPM Package](https://www.npmjs.com/package/react-on-rails), [react-on-rails/webpackConfigLoader](https://github.com/shakacode/react_on_rails/blob/master/webpackConfigLoader.js) to provide your Webpack config with easy access to the YAML settings. Even if you don't use the NPM package, you can use that file to inspire your Webpack configuration.
 

--- a/lib/webpacker_lite/helper.rb
+++ b/lib/webpacker_lite/helper.rb
@@ -12,9 +12,20 @@ module WebpackerLite::Helper
   # In production mode:
   #   <%= asset_pack_path 'calendar.css' %> # => "/public/webpack/production/calendar-1016838bab065ae1e122.css"
   def asset_pack_path(name, **options)
+    pack_path = pack_path(name)
+    asset_path(pack_path, **options)
+  end
+
+  # Computes the full path for a given webpacker asset.
+  # Return relative path using manifest.json and passes it to asset_url helper
+  # Examples:
+  #
+  # In production mode:
+  #   <%= asset_pack_path 'calendar.css' %> # => "webpack/production/calendar-1016838bab065ae1e122.css"
+  def pack_path(name)
     path = WebpackerLite::Configuration.base_path
     file = WebpackerLite::Manifest.lookup(name)
-    asset_path("#{path}/#{file}", **options)
+    "#{path}/#{file}"
   end
 
   # Creates a script tag that references the named pack file, as compiled by Webpack.

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -6,6 +6,11 @@ class HelperTest < ActionView::TestCase
     @view.extend WebpackerLite::Helper
   end
 
+  def test_pack_path
+    assert_equal @view.pack_path("bootstrap.js"), "/webpack/test/bootstrap-300631c4f0e0f9c865bc.js"
+    assert_equal @view.pack_path("bootstrap.css"), "/webpack/test/bootstrap-c38deda30895059837cf.css"
+  end
+
   def test_asset_pack_path
     assert_equal @view.asset_pack_path("bootstrap.js"), "/webpack/test/bootstrap-300631c4f0e0f9c865bc.js"
     assert_equal @view.asset_pack_path("bootstrap.css"), "/webpack/test/bootstrap-c38deda30895059837cf.css"


### PR DESCRIPTION
The `pack_path` is the same as the `asset_pack_path` except that the
Rails `asset_path` is not called on the file name. This is used by
server rendering, as the `asset_path` is designed for browsers to access
assets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/webpacker_lite/23)
<!-- Reviewable:end -->
